### PR TITLE
Handle viewer dependencies when CDN blocked

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -116,6 +116,25 @@ select:disabled {
   background: #0f172a;
 }
 
+#viewer-canvas[hidden] {
+  display: none;
+}
+
+.viewer--unavailable {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #1e293b;
+  color: #e2e8f0;
+}
+
+.viewer-unavailable {
+  padding: 1.5rem;
+  text-align: center;
+  line-height: 1.5;
+  font-weight: 500;
+}
+
 #viewer-canvas {
   width: 100%;
   height: 100%;

--- a/frontend/vendor/README.md
+++ b/frontend/vendor/README.md
@@ -1,0 +1,16 @@
+# Viewer vendor directory
+
+The front-end will try to load the Three.js viewer stack from the CDN first.
+If the CDN is unavailable (for example on restricted networks), place the
+required modules in the paths below so that the local fallback can be used
+instead:
+
+```
+frontend/vendor/three/build/three.module.js
+frontend/vendor/three/examples/jsm/controls/OrbitControls.js
+frontend/vendor/three/examples/jsm/loaders/GLTFLoader.js
+```
+
+The files should be copied from the matching Three.js release used by the
+application (currently `three@0.160.0`). They will be detected automatically—no
+code changes are needed after the files are present.


### PR DESCRIPTION
## Summary
- dynamically load the Three.js viewer stack with CDN/local fallbacks so the UI still initialises when the CDN is blocked
- surface a friendly viewer-unavailable notice and styling instead of leaving an empty canvas
- document where to place local Three.js bundles for offline deployments

## Testing
- not run (frontend-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d24df5202c832aa8ff101cf36f89d8